### PR TITLE
Fixed imports bug.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -35,10 +35,10 @@ import bpy
 from bpy.props import StringProperty, BoolProperty, FloatProperty, IntProperty, EnumProperty
 from bpy.types import Operator, Panel, Scene, Menu, AddonPreferences
 
-from modular_tree.generator_operators import MakeTreeOperator, BatchTreeOperator, MakeTwigOperator, UpdateTreeOperator, UpdateTwigOperator
-from modular_tree.presets import TreePresetLoadMenu, TreePresetRemoveMenu, SaveTreePresetOperator, InstallTreePresetOperator, RemoveTreePresetOperator, LoadTreePresetOperator
-from modular_tree.logo import display_logo
-from modular_tree.wind_setup_utils import WindOperator, MakeControllerOperator, MakeTerrainOperator
+from .generator_operators import MakeTreeOperator, BatchTreeOperator, MakeTwigOperator, UpdateTreeOperator, UpdateTwigOperator
+from .presets import TreePresetLoadMenu, TreePresetRemoveMenu, SaveTreePresetOperator, InstallTreePresetOperator, RemoveTreePresetOperator, LoadTreePresetOperator
+from .logo import display_logo
+from .wind_setup_utils import WindOperator, MakeControllerOperator, MakeTerrainOperator
 
 
 class TreeAddonPrefs(AddonPreferences):

--- a/generator_operators.py
+++ b/generator_operators.py
@@ -24,9 +24,9 @@ from math import sqrt
 import bpy
 from bpy.types import Operator, Panel, Scene, Menu, AddonPreferences
 
-from modular_tree.tree_creator import create_tree, add_leaf
-from modular_tree.prep_manager import save_everything
-from modular_tree.logo import display_logo
+from .tree_creator import create_tree, add_leaf
+from .prep_manager import save_everything
+from .logo import display_logo
 
 
 class MakeTreeOperator(Operator):

--- a/tree_creator.py
+++ b/tree_creator.py
@@ -23,10 +23,10 @@ from math import pi, radians
 
 import bpy
 
-from modular_tree.clock import Clock
-from modular_tree.uv_tools import rotate, add_seams
-from modular_tree.particle_configurator import create_system
-from modular_tree.material_tools import build_bark_material, build_leaf_material
+from .clock import Clock
+from .uv_tools import rotate, add_seams
+from .particle_configurator import create_system
+from .material_tools import build_bark_material, build_leaf_material
 
 
 class Module:

--- a/wind_setup_utils.py
+++ b/wind_setup_utils.py
@@ -21,8 +21,8 @@ import bpy
 from bpy.types import Operator, Panel, Scene, Menu, AddonPreferences
 import mathutils
 
-from modular_tree.prep_manager import save_everything
-from modular_tree.logo import display_logo
+from .prep_manager import save_everything
+from .logo import display_logo
 
 
 class WindOperator(Operator):


### PR DESCRIPTION
Changed to a relative import rather than explicitly `modular_tree.some_module` just `.some_module`. This should fix the import errors.