### PR TITLE
Added property group to store all properties outside of scene.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -20,8 +20,8 @@
 from random import randint
 
 import bpy
-from bpy.props import StringProperty, BoolProperty, FloatProperty, IntProperty, EnumProperty
-from bpy.types import Operator, Panel, Scene, Menu, AddonPreferences
+from bpy.props import StringProperty, BoolProperty, FloatProperty, IntProperty, EnumProperty, PointerProperty
+from bpy.types import Operator, Panel, Scene, Menu, AddonPreferences, PropertyGroup
 
 from .generator_operators import MakeTreeOperator, BatchTreeOperator, MakeTwigOperator, UpdateTreeOperator, UpdateTwigOperator
 from .presets import TreePresetLoadMenu, TreePresetRemoveMenu, SaveTreePresetOperator, InstallTreePresetOperator, RemoveTreePresetOperator, LoadTreePresetOperator
@@ -100,7 +100,7 @@ class MakeTreePanel(Panel):
     bl_category = 'Tree'
 
     def draw(self, context):
-        scene = context.scene
+        mtree_props = context.scene.mtree_props
         layout = self.layout
 
         row = layout.row()
@@ -113,14 +113,14 @@ class MakeTreePanel(Panel):
 
         box = layout.box()
         box.label("Basic")
-        box.prop(scene, "SeedProp")
-        box.prop(scene, "iteration")
-        box.prop(scene, 'radius')
-        box.prop(scene, 'uv')
-        if scene.uv:
-            box.prop(scene, 'finish_unwrap')
-            if scene.finish_unwrap:
-                box.prop(scene, "unwrap_end_iteration")
+        box.prop(mtree_props, "SeedProp")
+        box.prop(mtree_props, "iteration")
+        box.prop(mtree_props, 'radius')
+        box.prop(mtree_props, 'uv')
+        if mtree_props.uv:
+            box.prop(mtree_props, 'finish_unwrap')
+            if mtree_props.finish_unwrap:
+                box.prop(mtree_props, "unwrap_end_iteration")
 
 
 class BatchTreePanel(Panel):
@@ -133,16 +133,16 @@ class BatchTreePanel(Panel):
     bl_options = {'DEFAULT_CLOSED'}
     
     def draw(self, context):
-        scene = context.scene
+        mtree_props = context.scene.mtree_props
         layout = self.layout
         row = layout.row()
         row.scale_y = 1.5
         row.operator("mod_tree.batch_tree", icon="LOGIC")
         box = layout.box()
-        box.prop(scene, "tree_number")
-        box.prop(scene, "batch_radius_randomness")
-        box.prop_search(scene, "batch_group_name", bpy.data, "groups")
-        box.prop(scene, "batch_space")
+        box.prop(mtree_props, "tree_number")
+        box.prop(mtree_props, "batch_radius_randomness")
+        box.prop_search(mtree_props, "batch_group_name", bpy.data, "groups")
+        box.prop(mtree_props, "batch_space")
  
 
 class RootsAndTrunksPanel(Panel):
@@ -155,26 +155,26 @@ class RootsAndTrunksPanel(Panel):
     bl_options = {'DEFAULT_CLOSED'}
 
     def draw(self, context):
-        scene = context.scene
+        mtree_props = context.scene.mtree_props
         layout = self.layout
 
         box = layout.box()
         box.label("Roots")
-        box.prop(scene, 'create_roots')
-        if scene.create_roots:
-            box.prop(scene, 'roots_iteration')
+        box.prop(mtree_props, 'create_roots')
+        if mtree_props.create_roots:
+            box.prop(mtree_props, 'roots_iteration')
 
         box = layout.box()
         box.label("Trunk")
-        box.prop(scene, 'trunk_length')
-        box.prop(scene, 'trunk_variation')
-        box.prop(scene, 'trunk_space')
+        box.prop(mtree_props, 'trunk_length')
+        box.prop(mtree_props, 'trunk_variation')
+        box.prop(mtree_props, 'trunk_space')
         sbox = box.box()
-        sbox.prop(scene, 'preserve_trunk')
-        if scene.preserve_trunk:
-            sbox.prop(scene, 'preserve_end')
-            sbox.prop(scene, 'trunk_split_proba')
-            sbox.prop(scene, 'trunk_split_angle')
+        sbox.prop(mtree_props, 'preserve_trunk')
+        if mtree_props.preserve_trunk:
+            sbox.prop(mtree_props, 'preserve_end')
+            sbox.prop(mtree_props, 'trunk_split_proba')
+            sbox.prop(mtree_props, 'trunk_split_angle')
 
 
 class TreeBranchesPanel(Panel):
@@ -188,28 +188,29 @@ class TreeBranchesPanel(Panel):
 
     def draw(self, context):
         scene = context.scene
+        mtree_props = scene.mtree_props
         layout = self.layout
 
         box = layout.box()
         box.label("Branches")
-        box.prop(scene, 'break_chance')
-        box.prop(scene, 'branch_length')
-        box.prop(scene, 'randomangle')
-        box.prop(scene, 'split_proba')
-        box.prop(scene, 'split_angle')
-        box.prop(scene, 'radius_dec')
+        box.prop(mtree_props, 'break_chance')
+        box.prop(mtree_props, 'branch_length')
+        box.prop(mtree_props, 'randomangle')
+        box.prop(mtree_props, 'split_proba')
+        box.prop(mtree_props, 'split_angle')
+        box.prop(mtree_props, 'radius_dec')
         col = box.column(align=True)
-        col.prop(scene, 'branch_rotate')
-        col.prop(scene, 'branch_random_rotate')
+        col.prop(mtree_props, 'branch_rotate')
+        col.prop(mtree_props, 'branch_random_rotate')
 
         box = layout.box()
         col = box.column(True)
-        col.prop(scene, 'gravity_strength')
-        col.prop(scene, 'gravity_start')
-        col.prop(scene, 'gravity_end')
-        box.prop_search(scene, "obstacle", scene, "objects")
-        if bpy.data.objects.get(scene.obstacle) is not None:
-            box.prop(scene, 'obstacle_strength')
+        col.prop(mtree_props, 'gravity_strength')
+        col.prop(mtree_props, 'gravity_start')
+        col.prop(mtree_props, 'gravity_end')
+        box.prop_search(mtree_props, "obstacle", scene, "objects")
+        if bpy.data.objects.get(mtree_props.obstacle) is not None:
+            box.prop(mtree_props, 'obstacle_strength')
 
 
 class AdvancedSettingsPanel(Panel):
@@ -222,22 +223,22 @@ class AdvancedSettingsPanel(Panel):
     bl_options = {'DEFAULT_CLOSED'}
 
     def draw(self, context):
-        scene = context.scene
+        mtree_props = context.scene.mtree_props
         layout = self.layout
 
         box = layout.box()
-        box.prop(scene, 'mat')
-        if not scene.mat:
-            box.prop_search(scene, "bark_material", bpy.data, "materials")
-        box.prop(scene, 'create_armature')
-        if scene.create_armature:
-            box.prop(scene, 'bones_iterations')
-        box.prop(scene, 'visualize_leafs')
-        box.prop(scene, 'leafs_iteration_length')
-        box.prop(scene, 'particle')
-        if scene.particle:
-            box.prop(scene, 'number')
-            box.prop(scene, 'display')
+        box.prop(mtree_props, 'mat')
+        if not mtree_props.mat:
+            box.prop_search(mtree_props, "bark_material", bpy.data, "materials")
+        box.prop(mtree_props, 'create_armature')
+        if mtree_props.create_armature:
+            box.prop(mtree_props, 'bones_iterations')
+        box.prop(mtree_props, 'visualize_leafs')
+        box.prop(mtree_props, 'leafs_iteration_length')
+        box.prop(mtree_props, 'particle')
+        if mtree_props.particle:
+            box.prop(mtree_props, 'number')
+            box.prop(mtree_props, 'display')
 
 
 class WindAnimationPanel(Panel):
@@ -250,7 +251,7 @@ class WindAnimationPanel(Panel):
     bl_options = {'DEFAULT_CLOSED'}
 
     def draw(self, context):
-        scene = context.scene
+        mtree_props = context.scene.mtree_props
         layout = self.layout
 
         box = layout.box()
@@ -259,12 +260,12 @@ class WindAnimationPanel(Panel):
         row.operator("mod_tree.animate_wind", icon="FORCE_VORTEX")
         box.operator("mod_tree.make_wind_controller", icon="FORCE_VORTEX")
         box.operator("mod_tree.make_terrain", icon="FORCE_VORTEX")
-        box.prop_search(scene, "wind_controller", bpy.data, "objects")
-        box.prop_search(scene, "terrain", bpy.data, "objects")
-        box.prop(scene, "wind_height_start")
-        box.prop(scene, "wind_height_full")
-        box.prop(scene, "clear_mods")
-        box.prop(scene, "wind_strength")
+        box.prop_search(mtree_props, "wind_controller", bpy.data, "objects")
+        box.prop_search(mtree_props, "terrain", bpy.data, "objects")
+        box.prop(mtree_props, "wind_height_start")
+        box.prop(mtree_props, "wind_height_full")
+        box.prop(mtree_props, "clear_mods")
+        box.prop(mtree_props, "wind_strength")
 
 
 class MakeTwigPanel(Panel):
@@ -277,7 +278,7 @@ class MakeTwigPanel(Panel):
     bl_options = {'DEFAULT_CLOSED'}
 
     def draw(self, context):
-        scene = context.scene
+        mtree_props = context.scene.mtree_props
         layout = self.layout
 
         row = layout.row()
@@ -290,12 +291,12 @@ class MakeTwigPanel(Panel):
 
         box = layout.box()
         box.label("Twig Options")
-        box.prop(scene, "leaf_size")
-        box.prop(scene, "leaf_chance")
-        box.prop(scene, "TwigSeedProp")
-        box.prop(scene, "twig_iteration")
-        box.prop_search(scene, "twig_bark_material", bpy.data, "materials")
-        box.prop_search(scene, "twig_leaf_material", bpy.data, "materials")           
+        box.prop(mtree_props, "leaf_size")
+        box.prop(mtree_props, "leaf_chance")
+        box.prop(mtree_props, "TwigSeedProp")
+        box.prop(mtree_props, "twig_iteration")
+        box.prop_search(mtree_props, "twig_bark_material", bpy.data, "materials")
+        box.prop_search(mtree_props, "twig_leaf_material", bpy.data, "materials")           
 
 
 class MakeTreePresetsPanel(Panel):
@@ -307,7 +308,7 @@ class MakeTreePresetsPanel(Panel):
     bl_category = 'Tree'
 
     def draw(self, context):
-        scene = context.scene
+        mtree_props = context.scene.mtree_props
         layout = self.layout
 
         row = layout.row()
@@ -315,11 +316,271 @@ class MakeTreePresetsPanel(Panel):
         row.menu("mod_tree.preset_load_menu")
 
         row = layout.row(align=True)
-        row.prop(scene, "preset_name", text="")
+        row.prop(mtree_props, "preset_name", text="")
         row.operator("mod_tree.save_preset", icon="SETTINGS")
 
         row = layout.row()
         row.menu("mod_tree.preset_remove_menu")
+
+
+class ModularTreePropertyGroup(PropertyGroup):
+    """This is the set of all of the properties for modular tree."""
+    preset_name = StringProperty(name="Preset Name", default="MyPreset")
+
+    finish_unwrap = BoolProperty(
+        name="Unwrap",
+        description="Run 'Unwrap' operator. WARNING: slow, enable for final only",
+        default=True)
+
+    preserve_trunk = BoolProperty(
+        name="Preserve Trunk", default=False,
+        description="preserves the trunk growth, check and see.")
+
+    trunk_split_angle = FloatProperty(
+        name="Trunk Split Angle",
+        min=0.0,
+        max=1,
+        default=0,
+        description="how wide is the angle in a split if this split comes from the trunk")
+
+    randomangle = FloatProperty(
+        name="Branch Variations",
+        default=.5)
+
+    trunk_variation = FloatProperty(
+        name="Trunk Variation",
+        default=.1)
+
+    radius = FloatProperty(
+        name="Radius",
+        min=0.01,
+        default=1)
+
+    radius_dec = FloatProperty(
+        name="Radius Decrease",
+        min=0.01,
+        max=1.0,
+        default=0.95,
+        description="Relative radius after each iteration, low value means fast radius decrease")
+
+    iteration = IntProperty(
+        name="Branch Iterations",
+        min=2,
+        soft_max=30,
+        default=20)
+
+    preserve_end = IntProperty(
+        name="Trunk End",
+        min=0,
+        default=25,
+        description="iteration on which trunk preservation will end")
+
+    trunk_length = IntProperty(
+        name="Trunk Iterations",
+        min=5,
+        default=9,
+        description="Iteration from from which first split occurs")
+
+    trunk_split_proba = FloatProperty(
+        name="Trunk Split Probability",
+        min=0.0,
+        max=1.0,
+        default=0.5,
+        description="probability for a branch to split. WARNING : sensitive")
+
+    split_proba = FloatProperty(
+        name="Split Probability",
+        min=0.0,
+        max=1.0,
+        default=0.25,
+        description="Probability for a branch to split. \nWARNING : sensitive")
+
+    trunk_space = FloatProperty(
+        name="Trunk Length",
+        min=0.01,
+        default=.7,
+        description="Length of the trunk")
+
+    branch_length = FloatProperty(
+        name="Branch Length",
+        min=0.01,
+        default=.55,
+        description="Branch length")
+
+    split_angle = FloatProperty(
+        name="Split Angle",
+        min=0.0,
+        max=1,
+        default=.2,
+        description="Width of the angle in a split")
+
+    gravity_strength = FloatProperty(
+        name="Gravity Strength",
+        default=0.0)
+
+    gravity_start = IntProperty(
+        name="Gravity Start Iteration",
+        default=0)
+
+    gravity_end = IntProperty(
+        name="Gravity End Iteration",
+        default=40)
+
+    obstacle = StringProperty(
+        name='Obstacle',
+        default='',
+        description="Obstacle to avoid. \nWARNING: location,rotaion and scale must be applied. Check the normals.")
+
+    obstacle_strength = FloatProperty(
+        name="Obstacle Strength",
+        description='Strength with which to avoid obstacles',
+        default=1)
+
+    SeedProp = IntProperty(
+        name="Seed",
+        default=randint(0, 1000))
+
+    create_armature = BoolProperty(
+        name='Create Armature',
+        default=False)
+
+    bones_iterations = IntProperty(
+        name='Bones Iterations',
+        default=8)
+
+    visualize_leafs = BoolProperty(
+        name='Visualize Particle Weights',
+        default=False)
+
+    leafs_iteration_length = IntProperty(
+        name='Leafs Group Length',
+        default=4,
+        description="The number of branches iterations where leafs will appear")
+
+    uv = BoolProperty(
+        name="Create UV Seams",
+        default=False,
+        description="Create uv seams for tree (enable unwrap to auto unwrap)")
+
+    unwrap_end_iteration = IntProperty(
+        name="Last Unwrapped Iteration",
+        min=1,
+        soft_max=20,
+        default=8)
+
+    mat = BoolProperty(
+        name="Create New Material",
+        default=False,
+        description="NEEDS UV, create tree material")
+
+    roots_iteration = IntProperty(
+        name="Roots Iterations",
+        default=4)
+
+    create_roots = BoolProperty(
+        name="Create Roots",
+        default=False)
+
+    branch_rotate = FloatProperty(
+        name="Branches Rotation Angle",
+        default=90,
+        min=0,
+        max=360,
+        description="angle between new split and previous split")
+
+    branch_random_rotate = FloatProperty(
+        name="Branches Random Rotation Angle",
+        default=5,
+        min=0,
+        max=360,
+        description="randomize the rotation of branches angle")
+
+    particle = BoolProperty(
+        name="Configure Particle System",
+        default=False)
+
+    number = IntProperty(
+        name="Number of Leaves",
+        default=10000)
+
+    display = IntProperty(
+        name="Particles in Viewport",
+        default=500)
+
+    break_chance = FloatProperty(
+        name="Break Chance",
+        default=0.02)
+
+    bark_material = StringProperty(
+        name="Bark Material")
+
+    leaf_size = FloatProperty(
+        name="Leaf Size",
+        min=0,
+        default=1)
+
+    leaf_chance = FloatProperty(
+        name="Leaf Generation Probability",
+        min=0,
+        default=.5)
+
+    twig_leaf_material = StringProperty(
+        name="Leaf Material")
+
+    twig_bark_material = StringProperty(
+        name="Twig Bark Material")
+
+    TwigSeedProp = IntProperty(
+        name="Twig Seed",
+        default=randint(0, 1000))
+
+    twig_iteration = IntProperty(
+        name="Twig Iteration",
+        min=3,
+        soft_max=10,
+        default=9)
+
+    tree_number = IntProperty(
+        name="Tree Number",
+        min=2,
+        default=5)
+
+    batch_radius_randomness = FloatProperty(
+        name="Radius Randomness",
+        min=0,
+        max=1,
+        default=.5)
+
+    batch_group_name = StringProperty(
+        name="Group")
+
+    batch_space = FloatProperty(
+        name="Grid Size",
+        min=0,
+        default=10,
+        description="The distance between the trees")
+
+    wind_controller = StringProperty(
+        name="Control Object")
+
+    terrain = StringProperty(
+        name="Terrain")
+
+    wind_height_start = FloatProperty(
+        name="Start Height",
+        min=0,
+        default=0,
+        description="The distance from the terrain that the wind effect starts affecting tree")
+
+    wind_height_full = FloatProperty(
+        name="Full Height",
+        min=0,
+        default=10,
+        description="The distance from the terrain that the wind effect is at its highest")
+
+    clear_mods = BoolProperty(name="Clear Modifiers", default=True)
+
+    wind_strength = FloatProperty(name="Wind Strength", default=1)
 
 
 # classes to register (panels will be in the UI in the order they are listed here)
@@ -329,78 +590,78 @@ classes = [MakeTreeOperator, BatchTreeOperator, MakeTwigOperator, UpdateTreeOper
            MakeTreePanel, BatchTreePanel, RootsAndTrunksPanel, TreeBranchesPanel, AdvancedSettingsPanel,
            MakeTwigPanel, TreePresetLoadMenu, TreePresetRemoveMenu, WindAnimationPanel, MakeTreePresetsPanel,
            InstallTreePresetOperator, CheckForUpdates,
-           TreeAddonPrefs]
+           TreeAddonPrefs, ModularTreePropertyGroup]
 
 prefix = "https://github.com/MaximeHerpin/modular_tree/wiki/"
 documentation_mapping = (
     # make tree panel
     ("bpy.ops.mod_tree.add_tree", "Make-Tree-Panel#make-tree"),
     ("bpy.ops.mod_tree.update_tree", "Make-Tree-Panel#update-tree"),
-    ("bpy.types.Scene.SeedProp", "Make-Tree-Panel#seed"),
-    ("bpy.types.Scene.iteration", "Make-Tree-Panel#branch-iterations"),
-    ("bpy.types.Scene.radius", "Make-Tree-Panel#radius"),
-    ("bpy.types.Scene.uv", "Make-Tree-Panel#create-uv-seams"),
-    ("bpy.types.Scene.finish_unwrap", "Make-Tree-Panel#unwrap"),
-    ("bpy.types.Scene.unwrap_end_iteration", "Make-Tree-Panel#last-unwrapped-iteration"),
+    ("bpy.types.Scene.mtree_props.SeedProp", "Make-Tree-Panel#seed"),
+    ("bpy.types.Scene.mtree_props.iteration", "Make-Tree-Panel#branch-iterations"),
+    ("bpy.types.Scene.mtree_props.radius", "Make-Tree-Panel#radius"),
+    ("bpy.types.Scene.mtree_props.uv", "Make-Tree-Panel#create-uv-seams"),
+    ("bpy.types.Scene.mtree_props.finish_unwrap", "Make-Tree-Panel#unwrap"),
+    ("bpy.types.Scene.mtree_props.unwrap_end_iteration", "Make-Tree-Panel#last-unwrapped-iteration"),
     # roots and trunk
-    ("bpy.types.Scene.create_roots", "Roots-and-Trunk#create-roots"),
-    ("bpy.types.Scene.roots_iteration", "Roots-and-Trunk#roots-iterations"),
-    ("bpy.types.Scene.trunk_length", "Roots-and-Trunk#trunk-iterations"),
-    ("bpy.types.Scene.trunk_variation", "Roots-and-Trunk#trunk-variation"),
-    ("bpy.types.Scene.trunk_space", "Roots-and-Trunk#trunk-length"),
-    ("bpy.types.Scene.preserve_trunk", "Roots-and-Trunk#preserve-trunk"),
-    ("bpy.types.Scene.preserve_end", "Roots-and-Trunk#trunk-end"),
-    ("bpy.types.Scene.trunk_split_proba", "Roots-and-Trunk#trunk-split-probability"),
-    ("bpy.types.Scene.trunk_split_angle", "Roots-and-Trunk#trunk-split-angle"),
+    ("bpy.types.Scene.mtree_props.create_roots", "Roots-and-Trunk#create-roots"),
+    ("bpy.types.Scene.mtree_props.roots_iteration", "Roots-and-Trunk#roots-iterations"),
+    ("bpy.types.Scene.mtree_props.trunk_length", "Roots-and-Trunk#trunk-iterations"),
+    ("bpy.types.Scene.mtree_props.trunk_variation", "Roots-and-Trunk#trunk-variation"),
+    ("bpy.types.Scene.mtree_props.trunk_space", "Roots-and-Trunk#trunk-length"),
+    ("bpy.types.Scene.mtree_props.preserve_trunk", "Roots-and-Trunk#preserve-trunk"),
+    ("bpy.types.Scene.mtree_props.preserve_end", "Roots-and-Trunk#trunk-end"),
+    ("bpy.types.Scene.mtree_props.trunk_split_proba", "Roots-and-Trunk#trunk-split-probability"),
+    ("bpy.types.Scene.mtree_props.trunk_split_angle", "Roots-and-Trunk#trunk-split-angle"),
     # branches
-    ("bpy.types.Scene.break_chance", "Branches#break-chance"),
-    ("bpy.types.Scene.branch_length", "Branches#branch-length"),
-    ("bpy.types.Scene.randomangle", "Branches#branch-variations"),
-    ("bpy.types.Scene.split_proba", "Branches#split-probability"),
-    ("bpy.types.Scene.split_angle", "Branches#split-angle"),
-    ("bpy.types.Scene.radius_dec", "Branches#radius-decrease"),
-    ("bpy.types.Scene.branch_rotate", "Branches#branches-rotation-angle"),
-    ("bpy.types.Scene.branch_random_rotate", "Branches#branches-random-rotation-angle"),
-    ("bpy.types.Scene.gravity_strength", "Branches#gravity-strength"),
-    ("bpy.types.Scene.gravity_start", "Branches#gravity-start"),
-    ("bpy.types.Scene.gravity_end", "Branches#gravity-end"),
-    ("bpy.types.Scene.obstacle", "Branches#obstacle"),
-    ("bpy.types.Scene.obstacle_strength", "Branches#obstacle-strength"),
+    ("bpy.types.Scene.mtree_props.break_chance", "Branches#break-chance"),
+    ("bpy.types.Scene.mtree_props.branch_length", "Branches#branch-length"),
+    ("bpy.types.Scene.mtree_props.randomangle", "Branches#branch-variations"),
+    ("bpy.types.Scene.mtree_props.split_proba", "Branches#split-probability"),
+    ("bpy.types.Scene.mtree_props.split_angle", "Branches#split-angle"),
+    ("bpy.types.Scene.mtree_props.radius_dec", "Branches#radius-decrease"),
+    ("bpy.types.Scene.mtree_props.branch_rotate", "Branches#branches-rotation-angle"),
+    ("bpy.types.Scene.mtree_props.branch_random_rotate", "Branches#branches-random-rotation-angle"),
+    ("bpy.types.Scene.mtree_props.gravity_strength", "Branches#gravity-strength"),
+    ("bpy.types.Scene.mtree_props.gravity_start", "Branches#gravity-start"),
+    ("bpy.types.Scene.mtree_props.gravity_end", "Branches#gravity-end"),
+    ("bpy.types.Scene.mtree_props.obstacle", "Branches#obstacle"),
+    ("bpy.types.Scene.mtree_props.obstacle_strength", "Branches#obstacle-strength"),
     # advanced settings
-    ("bpy.types.Scene.mat", "Advanced-Settings#create-new-material"),
-    ("bpy.types.Scene.bark_material", "Advanced-Settings#bark-material"),
-    ("bpy.types.Scene.create_armature", "Advanced-Settings#create-armature"),
-    ("bpy.types.Scene.bones_iterations", "Advanced-Settings#bones-iterations"),
-    ("bpy.types.Scene.visualize_leafs", "Advanced-Settings#visualize-particle-weights"),
-    ("bpy.types.Scene.leafs_iteration_length", "Advanced-Settings#leafs-group-length"),
-    ("bpy.types.Scene.particle", "Advanced-Settings#configure-particle-system"),
-    ("bpy.types.Scene.number", "Advanced-Settings#number-of-leaves"),
-    ("bpy.types.Scene.display", "Advanced-Settings#particles-in-viewport"),
+    ("bpy.types.Scene.mtree_props.mat", "Advanced-Settings#create-new-material"),
+    ("bpy.types.Scene.mtree_props.bark_material", "Advanced-Settings#bark-material"),
+    ("bpy.types.Scene.mtree_props.create_armature", "Advanced-Settings#create-armature"),
+    ("bpy.types.Scene.mtree_props.bones_iterations", "Advanced-Settings#bones-iterations"),
+    ("bpy.types.Scene.mtree_props.visualize_leafs", "Advanced-Settings#visualize-particle-weights"),
+    ("bpy.types.Scene.mtree_props.leafs_iteration_length", "Advanced-Settings#leafs-group-length"),
+    ("bpy.types.Scene.mtree_props.particle", "Advanced-Settings#configure-particle-system"),
+    ("bpy.types.Scene.mtree_props.number", "Advanced-Settings#number-of-leaves"),
+    ("bpy.types.Scene.mtree_props.display", "Advanced-Settings#particles-in-viewport"),
     # batch tree generation
     ("bpy.ops.mod_tree.batch_tree", "Batch-Tree-Generation#batch-tree-generation"),
-    ("bpy.types.Scene.tree_number", "Batch-Tree-Generation#tree-number"),
-    ("bpy.types.Scene.batch_radius_randomness", "Batch-Tree-Generation#radius-randomness"),
-    ("bpy.types.Scene.batch_group_name", "Batch-Tree-Generation#group"),
-    ("bpy.types.Scene.batch_space", "Batch-Tree-Generation#grid-size"),
+    ("bpy.types.Scene.mtree_props.tree_number", "Batch-Tree-Generation#tree-number"),
+    ("bpy.types.Scene.mtree_props.batch_radius_randomness", "Batch-Tree-Generation#radius-randomness"),
+    ("bpy.types.Scene.mtree_props.batch_group_name", "Batch-Tree-Generation#group"),
+    ("bpy.types.Scene.mtree_props.batch_space", "Batch-Tree-Generation#grid-size"),
     # make twig
     ("bpy.ops.mod_tree.add_twig", "Make-Twig#create-twig"),
     ("bpy.ops.mod_tree.update_twig", "Make-Twig#update-selected-twig"),
-    ("bpy.types.Scene.leaf_size", "Make-Twig#leaf-size"),
-    ("bpy.types.Scene.leaf_chance", "Make-Twig#leaf-generation-probability"),
-    ("bpy.types.Scene.TwigSeedProp", "Make-Twig#twig-seed"),
-    ("bpy.types.Scene.twig_iteration", "Make-Twig#twig-iteration"),
-    ("bpy.types.Scene.twig_bark_material", "Make-Twig#twig-bark-material"),
-    ("bpy.types.Scene.twig_leaf_material", "Make-Twig#twig-leaf-material"),
+    ("bpy.types.Scene.mtree_props.leaf_size", "Make-Twig#leaf-size"),
+    ("bpy.types.Scene.mtree_props.leaf_chance", "Make-Twig#leaf-generation-probability"),
+    ("bpy.types.Scene.mtree_props.TwigSeedProp", "Make-Twig#twig-seed"),
+    ("bpy.types.Scene.mtree_props.twig_iteration", "Make-Twig#twig-iteration"),
+    ("bpy.types.Scene.mtree_props.twig_bark_material", "Make-Twig#twig-bark-material"),
+    ("bpy.types.Scene.mtree_props.twig_leaf_material", "Make-Twig#twig-leaf-material"),
     # wind animation
     ("bpy.ops.mod_tree.animate_wind", "Wind-Animation#animate-wind"),
     ("bpy.ops.mod_tree.make_wind_controller", "Wind-Animation#make-wind-controller"),
     ("bpy.ops.mod_tree.make_terrain", "Wind-Animation#make-terrain"),
-    ("bpy.types.Scene.wind_controller", "Wind-Animation#control-object"),
-    ("bpy.types.Scene.terrain", "Wind-Animation#terrain-object"),
-    ("bpy.types.Scene.wind_height_start", "Wind-Animation#start-height"),
-    ("bpy.types.Scene.wind_height_full", "Wind-Animation#full-height"),
-    ("bpy.types.Scene.clear_mods", "Wind-Animation#clear-modifiers"),
-    ("bpy.types.Scene.wind_strength", "Wind-Animation#wind-strength"),
+    ("bpy.types.Scene.mtree_props.wind_controller", "Wind-Animation#control-object"),
+    ("bpy.types.Scene.mtree_props.terrain", "Wind-Animation#terrain-object"),
+    ("bpy.types.Scene.mtree_props.wind_height_start", "Wind-Animation#start-height"),
+    ("bpy.types.Scene.mtree_props.wind_height_full", "Wind-Animation#full-height"),
+    ("bpy.types.Scene.mtree_props.clear_mods", "Wind-Animation#clear-modifiers"),
+    ("bpy.types.Scene.mtree_props.wind_strength", "Wind-Animation#wind-strength"),
     # addon preferences
     ("bpy.ops.mod_tree.check_for_updates", "Addon-Preferences#save-blend-file"),
     ("bpy.ops.mod_tree.install_preset", "Addon-Preferences#save-images"),
@@ -427,261 +688,7 @@ def register():
     bpy.utils.register_manual_map(doc_map)
 
     # register props
-    Scene.preset_name = StringProperty(name="Preset Name", default="MyPreset")
-
-    Scene.finish_unwrap = BoolProperty(name="Unwrap",
-                                       description="Run 'Unwrap' operator. WARNING: slow, enable for final only",
-                                       default=True)
-
-    Scene.preserve_trunk = BoolProperty(
-        name="Preserve Trunk", default=False,
-        description="preserves the trunk growth, check and see.")
-
-    Scene.trunk_split_angle = FloatProperty(
-        name="Trunk Split Angle",
-        min=0.0,
-        max=1,
-        default=0,
-        description="how wide is the angle in a split if this split comes from the trunk")
-
-    Scene.randomangle = FloatProperty(
-        name="Branch Variations",
-        default=.5)
-
-    Scene.trunk_variation = FloatProperty(
-        name="Trunk Variation",
-        default=.1)
-
-    Scene.radius = FloatProperty(
-        name="Radius",
-        min=0.01,
-        default=1)
-
-    Scene.radius_dec = FloatProperty(
-        name="Radius Decrease",
-        min=0.01,
-        max=1.0,
-        default=0.95,
-        description="Relative radius after each iteration, low value means fast radius decrease")
-
-    Scene.iteration = IntProperty(
-        name="Branch Iterations",
-        min=2,
-        soft_max=30,
-        default=20)
-
-    Scene.preserve_end = IntProperty(
-        name="Trunk End",
-        min=0,
-        default=25,
-        description="iteration on which trunk preservation will end")
-
-    Scene.trunk_length = IntProperty(
-        name="Trunk Iterations",
-        min=5,
-        default=9,
-        description="Iteration from from which first split occurs")
-
-    Scene.trunk_split_proba = FloatProperty(
-        name="Trunk Split Probability",
-        min=0.0,
-        max=1.0,
-        default=0.5,
-        description="probability for a branch to split. WARNING : sensitive")
-
-    Scene.split_proba = FloatProperty(
-        name="Split Probability",
-        min=0.0,
-        max=1.0,
-        default=0.25,
-        description="Probability for a branch to split. \nWARNING : sensitive")
-
-    Scene.trunk_space = FloatProperty(
-        name="Trunk Length",
-        min=0.01,
-        default=.7,
-        description="Length of the trunk")
-
-    Scene.branch_length = FloatProperty(
-        name="Branch Length",
-        min=0.01,
-        default=.55,
-        description="Branch length")
-
-    Scene.split_angle = FloatProperty(
-        name="Split Angle",
-        min=0.0,
-        max=1,
-        default=.2,
-        description="Width of the angle in a split")
-
-    Scene.gravity_strength = FloatProperty(
-        name="Gravity Strength",
-        default=0.0)
-
-    Scene.gravity_start = IntProperty(
-        name="Gravity Start Iteration",
-        default=0)
-
-    Scene.gravity_end = IntProperty(
-        name="Gravity End Iteration",
-        default=40)
-
-    Scene.obstacle = StringProperty(
-        name='Obstacle',
-        default='',
-        description="Obstacle to avoid. \nWARNING: location,rotaion and scale must be applied. Check the normals.")
-
-    Scene.obstacle_strength = FloatProperty(
-        name="Obstacle Strength",
-        description='Strength with which to avoid obstacles',
-        default=1)
-
-    Scene.SeedProp = IntProperty(
-        name="Seed",
-        default=randint(0, 1000))
-
-    Scene.create_armature = BoolProperty(
-        name='Create Armature',
-        default=False)
-
-    Scene.bones_iterations = IntProperty(
-        name='Bones Iterations',
-        default=8)
-
-    Scene.visualize_leafs = BoolProperty(
-        name='Visualize Particle Weights',
-        default=False)
-
-    Scene.leafs_iteration_length = IntProperty(
-        name='Leafs Group Length',
-        default=4,
-        description="The number of branches iterations where leafs will appear")
-
-    Scene.uv = BoolProperty(
-        name="Create UV Seams",
-        default=False,
-        description="Create uv seams for tree (enable unwrap to auto unwrap)")
-    
-    Scene.unwrap_end_iteration = IntProperty(
-        name="Last Unwrapped Iteration",
-        min=1,
-        soft_max=20,
-        default=8)
-
-    Scene.mat = BoolProperty(
-        name="Create New Material",
-        default=False,
-        description="NEEDS UV, create tree material")
-
-    Scene.roots_iteration = IntProperty(
-        name="Roots Iterations",
-        default=4)
-
-    Scene.create_roots = BoolProperty(
-        name="Create Roots",
-        default=False)
-
-    Scene.branch_rotate = FloatProperty(
-        name="Branches Rotation Angle",
-        default=90,
-        min=0,
-        max=360,
-        description="angle between new split and previous split")
-
-    Scene.branch_random_rotate = FloatProperty(
-        name="Branches Random Rotation Angle",
-        default=5,
-        min=0,
-        max=360,
-        description="randomize the rotation of branches angle")
-
-    Scene.particle = BoolProperty(
-        name="Configure Particle System",
-        default=False)
-
-    Scene.number = IntProperty(
-        name="Number of Leaves",
-        default=10000)
-
-    Scene.display = IntProperty(
-        name="Particles in Viewport",
-        default=500)
-
-    Scene.break_chance = FloatProperty(
-        name="Break Chance",
-        default=0.02)
-
-    Scene.bark_material = StringProperty(
-        name="Bark Material")
-    
-    Scene.leaf_size = FloatProperty(
-        name="Leaf Size",
-        min=0,
-        default=1)
-    
-    Scene.leaf_chance = FloatProperty(
-        name="Leaf Generation Probability",
-        min=0,
-        default=.5)
-    
-    Scene.twig_leaf_material = StringProperty(
-        name="Leaf Material")
-    
-    Scene.twig_bark_material = StringProperty(
-        name="Twig Bark Material")
-    
-    Scene.TwigSeedProp = IntProperty(
-        name="Twig Seed",
-        default=randint(0, 1000))
-    
-    Scene.twig_iteration = IntProperty(
-        name="Twig Iteration",
-        min=3,
-        soft_max=10,
-        default=9)
-    
-    Scene.tree_number = IntProperty(
-        name="Tree Number",
-        min=2,
-        default=5)
-    
-    Scene.batch_radius_randomness = FloatProperty(
-        name="Radius Randomness",
-        min=0,
-        max=1,
-        default=.5)
-    
-    Scene.batch_group_name = StringProperty(
-        name="Group")
-    
-    Scene.batch_space = FloatProperty(
-        name="Grid Size",
-        min=0,
-        default=10,
-        description="The distance between the trees")
-
-    Scene.wind_controller = StringProperty(
-        name="Control Object")
-
-    Scene.terrain = StringProperty(
-        name="Terrain")
-
-    Scene.wind_height_start = FloatProperty(
-        name="Start Height",
-        min=0,
-        default=0,
-        description="The distance from the terrain that the wind effect starts affecting tree")
-
-    Scene.wind_height_full = FloatProperty(
-        name="Full Height",
-        min=0,
-        default=10,
-        description="The distance from the terrain that the wind effect is at its highest")
-
-    Scene.clear_mods = BoolProperty(name="Clear Modifiers", default=True)
-
-    Scene.wind_strength = FloatProperty(name="Wind Strength", default=1)
+    Scene.mtree_props = PointerProperty(type=ModularTreePropertyGroup)
 
 
 def unregister():
@@ -693,58 +700,7 @@ def unregister():
     bpy.utils.unregister_manual_map(doc_map)
 
     # unregister props
-    del Scene.preset_name
-    del Scene.finish_unwrap
-    del Scene.preserve_trunk
-    del Scene.trunk_split_angle
-    del Scene.randomangle
-    del Scene.trunk_variation
-    del Scene.radius
-    del Scene.radius_dec
-    del Scene.iteration
-    del Scene.preserve_end
-    del Scene.trunk_length
-    del Scene.trunk_split_proba
-    del Scene.split_proba
-    del Scene.trunk_space
-    del Scene.branch_length
-    del Scene.split_angle
-    del Scene.gravity_strength
-    del Scene.gravity_start
-    del Scene.gravity_end
-    del Scene.obstacle
-    del Scene.obstacle_strength
-    del Scene.SeedProp
-    del Scene.create_armature
-    del Scene.bones_iterations
-    del Scene.visualize_leafs
-    del Scene.leafs_iteration_length
-    del Scene.uv
-    del Scene.unwrap_end_iteration
-    del Scene.mat
-    del Scene.roots_iteration
-    del Scene.create_roots
-    del Scene.branch_rotate
-    del Scene.branch_random_rotate
-    del Scene.particle
-    del Scene.number
-    del Scene.display
-    del Scene.leaf_size
-    del Scene.leaf_chance
-    del Scene.twig_leaf_material
-    del Scene.twig_bark_material
-    del Scene.TwigSeedProp
-    del Scene.twig_iteration
-    del Scene.tree_number
-    del Scene.batch_radius_randomness
-    del Scene.batch_group_name
-    del Scene.batch_space
-    del Scene.wind_controller
-    del Scene.terrain
-    del Scene.wind_height_start
-    del Scene.wind_height_full
-    del Scene.clear_mods
-    del Scene.wind_strength
+    del Scene.mtree_props
 
 
 if __name__ == "__main__":

--- a/generator_operators.py
+++ b/generator_operators.py
@@ -46,8 +46,8 @@ class MakeTreeOperator(Operator):
 
         scene = context.scene
 
-        seed(scene.SeedProp)
-        create_tree(bpy.context.scene.cursor_location)
+        seed(scene.mtree_props.SeedProp)
+        create_tree(scene.cursor_location)
 
         return {'FINISHED'}
 
@@ -66,31 +66,31 @@ class BatchTreeOperator(Operator):
             self.report({message_lvls[i]}, message)
             return {status}
 
-        scene = context.scene
+        mtree_props = context.scene.mtree_props
         trees = []
-        save_radius = scene.radius
-        space = scene.batch_space
+        save_radius = mtree_props.radius
+        space = mtree_props.batch_space
         seeds = []
-        if scene.batch_group_name != "":
-            if scene.batch_group_name not in bpy.data.groups:
-                bpy.ops.group.create(name=scene.batch_group_name)
-        for i in range(scene.tree_number):
+        if mtree_props.batch_group_name != "":
+            if mtree_props.batch_group_name not in bpy.data.groups:
+                bpy.ops.group.create(name=mtree_props.batch_group_name)
+        for i in range(mtree_props.tree_number):
             new_seed = randint(0, 1000)
             while new_seed in seeds:
                 new_seed = randint(0, 1000)
-            pointer = int(sqrt(scene.tree_number))
+            pointer = int(sqrt(mtree_props.tree_number))
             pos_x = i % pointer
             pos_y = i // pointer
             seed(new_seed)
-            scene.radius = save_radius * (1 + scene.batch_radius_randomness * (.5 - random()) * 2)
+            mtree_props.radius = save_radius * (1 + mtree_props.batch_radius_randomness * (.5 - random()) * 2)
             create_tree(Vector((-space * pointer / 2, -space * pointer / 2, 0)) + Vector((pos_x, pos_y, 0)) * space)
             trees.append(bpy.context.active_object)
-            if scene.batch_group_name != "":
-                bpy.ops.object.group_link(group=scene.batch_group_name)
+            if mtree_props.batch_group_name != "":
+                bpy.ops.object.group_link(group=mtree_props.batch_group_name)
         for tree in trees:
             tree.select = True
 
-        scene.radius = save_radius
+        mtree_props.radius = save_radius
         return {'FINISHED'}
 
 
@@ -109,76 +109,78 @@ class MakeTwigOperator(Operator):
             return {status}
 
         scene = context.scene
-        seed(scene.TwigSeedProp)
-        save_preserve_trunk = scene.preserve_trunk
-        save_trunk_split_angle = scene.split_angle  # This variable is never used! Should it be?
-        save_randomangle = scene.randomangle
-        save_trunk_variation = scene.trunk_variation
-        save_radius = scene.radius
-        save_radius_dec = scene.radius_dec
-        save_iteration = scene.iteration
-        save_preserve_end = scene.preserve_end
-        save_trunk_length = scene.trunk_length
-        save_trunk_split_proba = scene.trunk_split_proba
-        save_trunk_space = scene.trunk_space
-        save_split_proba = scene.split_proba
-        save_branch_length = scene.branch_length
-        save_split_angle = scene.split_angle
-        save_gravity_strength = scene.gravity_strength
-        save_gravity_start = scene.gravity_start
-        save_gravity_end = scene.gravity_end
-        save_obstacle = scene.obstacle
-        save_obstacle_strength = scene.obstacle_strength
-        save_SeedProp = scene.SeedProp
-        save_create_armature = scene.create_armature
-        save_bones_iterations = scene.bones_iterations
-        save_visualize_leafs = scene.visualize_leafs
-        save_leafs_iteration_length = scene.leafs_iteration_length
-        save_uv = scene.uv
-        save_mat = scene.mat
-        save_roots_iteration = scene.roots_iteration
-        save_create_roots = scene.create_roots
-        save_branch_rotate = scene.branch_rotate
-        save_branch_random_rotate = scene.branch_random_rotate
-        save_particle = scene.particle
-        save_number = scene.number
-        save_display = scene.display
-        save_break_chance = scene.break_chance
+        mtree_props = scene.mtree_props
 
-        scene.preserve_trunk = False
-        scene.trunk_split_angle = 0
-        scene.randomangle = .5
-        scene.trunk_variation = .1
-        scene.radius = .25
-        scene.radius_dec = .85
-        scene.iteration = scene.twig_iteration
-        scene.preserve_end = 40
-        scene.trunk_length = 0
-        scene.trunk_split_proba = .2
-        scene.trunk_space = .1
-        scene.split_proba = .7
-        scene.branch_length = 3
-        scene.split_angle = .2
-        scene.gravity_strength = 0
-        scene.gravity_start = 0
-        scene.gravity_end = 0
-        scene.obstacle = ''
-        scene.obstacle_strength = 0
-        scene.SeedProp = scene.SeedProp
-        scene.create_armature = False
-        scene.bones_iterations = 10
-        scene.visualize_leafs = False
-        scene.leafs_iteration_length = 7
-        scene.uv = True
-        scene.mat = scene.mat
-        scene.roots_iteration = 0
-        scene.create_roots = False
-        scene.branch_rotate = 0
-        scene.branch_random_rotate = 15
-        scene.particle = False
-        scene.number = 0
-        scene.display = 0
-        scene.break_chance = 0
+        seed(mtree_props.TwigSeedProp)
+        save_preserve_trunk = mtree_props.preserve_trunk
+        save_trunk_split_angle = mtree_props.split_angle  # This variable is never used! Should it be?
+        save_randomangle = mtree_props.randomangle
+        save_trunk_variation = mtree_props.trunk_variation
+        save_radius = mtree_props.radius
+        save_radius_dec = mtree_props.radius_dec
+        save_iteration = mtree_props.iteration
+        save_preserve_end = mtree_props.preserve_end
+        save_trunk_length = mtree_props.trunk_length
+        save_trunk_split_proba = mtree_props.trunk_split_proba
+        save_trunk_space = mtree_props.trunk_space
+        save_split_proba = mtree_props.split_proba
+        save_branch_length = mtree_props.branch_length
+        save_split_angle = mtree_props.split_angle
+        save_gravity_strength = mtree_props.gravity_strength
+        save_gravity_start = mtree_props.gravity_start
+        save_gravity_end = mtree_props.gravity_end
+        save_obstacle = mtree_props.obstacle
+        save_obstacle_strength = mtree_props.obstacle_strength
+        save_SeedProp = mtree_props.SeedProp
+        save_create_armature = mtree_props.create_armature
+        save_bones_iterations = mtree_props.bones_iterations
+        save_visualize_leafs = mtree_props.visualize_leafs
+        save_leafs_iteration_length = mtree_props.leafs_iteration_length
+        save_uv = mtree_props.uv
+        save_mat = mtree_props.mat
+        save_roots_iteration = mtree_props.roots_iteration
+        save_create_roots = mtree_props.create_roots
+        save_branch_rotate = mtree_props.branch_rotate
+        save_branch_random_rotate = mtree_props.branch_random_rotate
+        save_particle = mtree_props.particle
+        save_number = mtree_props.number
+        save_display = mtree_props.display
+        save_break_chance = mtree_props.break_chance
+
+        mtree_props.preserve_trunk = False
+        mtree_props.trunk_split_angle = 0
+        mtree_props.randomangle = .5
+        mtree_props.trunk_variation = .1
+        mtree_props.radius = .25
+        mtree_props.radius_dec = .85
+        mtree_props.iteration = mtree_props.twig_iteration
+        mtree_props.preserve_end = 40
+        mtree_props.trunk_length = 0
+        mtree_props.trunk_split_proba = .2
+        mtree_props.trunk_space = .1
+        mtree_props.split_proba = .7
+        mtree_props.branch_length = 3
+        mtree_props.split_angle = .2
+        mtree_props.gravity_strength = 0
+        mtree_props.gravity_start = 0
+        mtree_props.gravity_end = 0
+        mtree_props.obstacle = ''
+        mtree_props.obstacle_strength = 0
+        mtree_props.SeedProp = mtree_props.SeedProp
+        mtree_props.create_armature = False
+        mtree_props.bones_iterations = 10
+        mtree_props.visualize_leafs = False
+        mtree_props.leafs_iteration_length = 7
+        mtree_props.uv = True
+        mtree_props.mat = mtree_props.mat
+        mtree_props.roots_iteration = 0
+        mtree_props.create_roots = False
+        mtree_props.branch_rotate = 0
+        mtree_props.branch_random_rotate = 15
+        mtree_props.particle = False
+        mtree_props.number = 0
+        mtree_props.display = 0
+        mtree_props.break_chance = 0
 
         if bpy.data.materials.get("twig bark") is None:
             build_bark_material("twig bark")
@@ -186,16 +188,16 @@ class MakeTwigOperator(Operator):
         if bpy.data.materials.get("twig leaf") is None:
             build_leaf_material("twig leaf")
 
-        twig_leafs = create_tree(bpy.context.scene.cursor_location, is_twig=True)
+        twig_leafs = create_tree(scene.cursor_location, is_twig=True)
         twig = bpy.context.active_object
         twig.name = 'twig'
-        twig.active_material = bpy.data.materials.get(scene.twig_bark_material)
+        twig.active_material = bpy.data.materials.get(mtree_props.twig_bark_material)
         for (position, direction, rotation) in twig_leafs:
             for i in range(randint(1, 3)):
-                if random() < scene.leaf_chance:
+                if random() < mtree_props.leaf_chance:
                     add_leaf(position + direction * .5 * random(), direction + Vector((random(), random(), random())),
-                             rotation + random() * 5, (1 + random()) * scene.leaf_size)
-                    bpy.context.active_object.active_material = bpy.data.materials.get(scene.twig_leaf_material)
+                             rotation + random() * 5, (1 + random()) * mtree_props.leaf_size)
+                    bpy.context.active_object.active_material = bpy.data.materials.get(mtree_props.twig_leaf_material)
                     twig.select = True
                     scene.objects.active = twig
         bpy.ops.object.join()
@@ -203,40 +205,40 @@ class MakeTwigOperator(Operator):
         bpy.ops.transform.resize(value=(0.25, 0.25, 0.25))
         bpy.ops.object.transform_apply(location=False, rotation=True, scale=True)
 
-        scene.preserve_trunk = save_preserve_trunk
-        scene.trunk_split_angle = save_split_angle
-        scene.randomangle = save_randomangle
-        scene.trunk_variation = save_trunk_variation
-        scene.radius = save_radius
-        scene.radius_dec = save_radius_dec
-        scene.iteration = save_iteration
-        scene.preserve_end = save_preserve_end
-        scene.trunk_length = save_trunk_length
-        scene.trunk_split_proba = save_trunk_split_proba
-        scene.trunk_space = save_trunk_space
-        scene.split_proba = save_split_proba
-        scene.branch_length = save_branch_length
-        scene.split_angle = save_split_angle
-        scene.gravity_strength = save_gravity_strength
-        scene.gravity_start = save_gravity_start
-        scene.gravity_end = save_gravity_end
-        scene.obstacle = save_obstacle
-        scene.obstacle_strength = save_obstacle_strength
-        scene.SeedProp = save_SeedProp
-        scene.create_armature = save_create_armature
-        scene.bones_iterations = save_bones_iterations
-        scene.visualize_leafs = save_visualize_leafs
-        scene.leafs_iteration_length = save_leafs_iteration_length
-        scene.uv = save_uv
-        scene.mat = save_mat
-        scene.roots_iteration = save_roots_iteration
-        scene.create_roots = save_create_roots
-        scene.branch_rotate = save_branch_rotate
-        scene.branch_random_rotate = save_branch_random_rotate
-        scene.particle = save_particle
-        scene.number = save_number
-        scene.display = save_display
-        scene.break_chance = save_break_chance
+        mtree_props.preserve_trunk = save_preserve_trunk
+        mtree_props.trunk_split_angle = save_split_angle
+        mtree_props.randomangle = save_randomangle
+        mtree_props.trunk_variation = save_trunk_variation
+        mtree_props.radius = save_radius
+        mtree_props.radius_dec = save_radius_dec
+        mtree_props.iteration = save_iteration
+        mtree_props.preserve_end = save_preserve_end
+        mtree_props.trunk_length = save_trunk_length
+        mtree_props.trunk_split_proba = save_trunk_split_proba
+        mtree_props.trunk_space = save_trunk_space
+        mtree_props.split_proba = save_split_proba
+        mtree_props.branch_length = save_branch_length
+        mtree_props.split_angle = save_split_angle
+        mtree_props.gravity_strength = save_gravity_strength
+        mtree_props.gravity_start = save_gravity_start
+        mtree_props.gravity_end = save_gravity_end
+        mtree_props.obstacle = save_obstacle
+        mtree_props.obstacle_strength = save_obstacle_strength
+        mtree_props.SeedProp = save_SeedProp
+        mtree_props.create_armature = save_create_armature
+        mtree_props.bones_iterations = save_bones_iterations
+        mtree_props.visualize_leafs = save_visualize_leafs
+        mtree_props.leafs_iteration_length = save_leafs_iteration_length
+        mtree_props.uv = save_uv
+        mtree_props.mat = save_mat
+        mtree_props.roots_iteration = save_roots_iteration
+        mtree_props.create_roots = save_create_roots
+        mtree_props.branch_rotate = save_branch_rotate
+        mtree_props.branch_random_rotate = save_branch_random_rotate
+        mtree_props.particle = save_particle
+        mtree_props.number = save_number
+        mtree_props.display = save_display
+        mtree_props.break_chance = save_break_chance
 
         return {'FINISHED'}
 
@@ -255,9 +257,9 @@ class UpdateTreeOperator(Operator):
             self.report({message_lvls[i]}, message)
             return {status}
 
-        scene = context.scene
+        mtree_props = context.scene.mtree_props
 
-        seed(scene.SeedProp)
+        seed(mtree_props.SeedProp)
         obj = bpy.context.active_object
 
         try:
@@ -272,7 +274,7 @@ class UpdateTreeOperator(Operator):
             scale = obj.scale
             rot = obj.rotation_euler
             create_tree(pos)
-            ob = bpy.context.active_object  # this is the new object that has been set active by 'create_tree'
+            ob = context.active_object  # this is the new object that has been set active by 'create_tree'
             ob.scale = scale
             ob.rotation_euler = rot
             ob.select = False
@@ -284,7 +286,7 @@ class UpdateTreeOperator(Operator):
                 arm_rot = obj.parent.rotation_euler
                 obj.parent.select = True
 
-                if scene.create_armature:
+                if mtree_props.create_armature:
                     ob.parent.location = arm_pos
                     ob.parent.scale = arm_scale
                     ob.parent.rotation_euler = arm_rot
@@ -317,9 +319,9 @@ class UpdateTwigOperator(Operator):
             self.report({message_lvls[i]}, message)
             return {status}
 
-        scene = context.scene
+        mtree_props = context.scene.mtree_props
 
-        seed(scene.SeedProp)
+        seed(mtree_props.SeedProp)
         obj = bpy.context.active_object
 
         try:
@@ -329,7 +331,7 @@ class UpdateTwigOperator(Operator):
             return {'CANCELLED'}
 
         if is_tree_prop:
-            pos = obj.location
+            pos = obj.location  # this is never used...should it be?
             scale = obj.scale
             rot = obj.rotation_euler
             bpy.ops.mod_tree.add_twig()

--- a/presets.py
+++ b/presets.py
@@ -68,7 +68,7 @@ class SaveTreePresetOperator(Operator):
     bl_options = {"REGISTER"}
 
     def execute(self, context):
-        scene = context.scene
+        mtree_props = context.scene.mtree_props
 
         preset = ("finish_unwrap:{}\n"
                   "preserve_trunk:{}\n"
@@ -119,57 +119,57 @@ class SaveTreePresetOperator(Operator):
                   "batch_space:{}\n".format(
                     # bools can't be stored as "True" or "False" b/c bool(x) will evaluate to
                     # True if x = "True" or if x = "False"...the fix is to do an int() conversion
-                    int(scene.finish_unwrap),
-                    int(scene.preserve_trunk),
-                    scene.trunk_split_angle,
-                    scene.randomangle,
-                    scene.trunk_variation,
-                    scene.radius,
-                    scene.radius_dec,
-                    scene.iteration,
-                    scene.preserve_end,
-                    scene.trunk_length,
-                    scene.trunk_split_proba,
-                    scene.split_proba,
-                    scene.trunk_space,
-                    scene.branch_length,
-                    scene.split_angle,
-                    scene.gravity_strength,
-                    scene.gravity_start,
-                    scene.gravity_end,
-                    scene.obstacle,
-                    scene.obstacle_strength,
-                    scene.SeedProp,
-                    int(scene.create_armature),
-                    scene.bones_iterations,
-                    int(scene.visualize_leafs),
-                    scene.leafs_iteration_length,
-                    int(scene.uv),
-                    int(scene.unwrap_end_iteration),
-                    int(scene.mat),
-                    scene.roots_iteration,
-                    int(scene.create_roots),
-                    scene.branch_rotate,
-                    scene.branch_random_rotate,
-                    int(scene.particle),
-                    scene.number,
-                    scene.display,
-                    scene.break_chance,
-                    scene.bark_material,
-                    scene.leaf_size,
-                    scene.leaf_chance,
-                    scene.twig_leaf_material,
-                    scene.twig_bark_material,
-                    scene.TwigSeedProp,
-                    scene.twig_iteration,
-                    scene.tree_number,
-                    scene.batch_radius_randomness,
-                    scene.batch_group_name,
-                    scene.batch_space))
+                    int(mtree_props.finish_unwrap),
+                    int(mtree_props.preserve_trunk),
+                    mtree_props.trunk_split_angle,
+                    mtree_props.randomangle,
+                    mtree_props.trunk_variation,
+                    mtree_props.radius,
+                    mtree_props.radius_dec,
+                    mtree_props.iteration,
+                    mtree_props.preserve_end,
+                    mtree_props.trunk_length,
+                    mtree_props.trunk_split_proba,
+                    mtree_props.split_proba,
+                    mtree_props.trunk_space,
+                    mtree_props.branch_length,
+                    mtree_props.split_angle,
+                    mtree_props.gravity_strength,
+                    mtree_props.gravity_start,
+                    mtree_props.gravity_end,
+                    mtree_props.obstacle,
+                    mtree_props.obstacle_strength,
+                    mtree_props.SeedProp,
+                    int(mtree_props.create_armature),
+                    mtree_props.bones_iterations,
+                    int(mtree_props.visualize_leafs),
+                    mtree_props.leafs_iteration_length,
+                    int(mtree_props.uv),
+                    int(mtree_props.unwrap_end_iteration),
+                    int(mtree_props.mat),
+                    mtree_props.roots_iteration,
+                    int(mtree_props.create_roots),
+                    mtree_props.branch_rotate,
+                    mtree_props.branch_random_rotate,
+                    int(mtree_props.particle),
+                    mtree_props.number,
+                    mtree_props.display,
+                    mtree_props.break_chance,
+                    mtree_props.bark_material,
+                    mtree_props.leaf_size,
+                    mtree_props.leaf_chance,
+                    mtree_props.twig_leaf_material,
+                    mtree_props.twig_bark_material,
+                    mtree_props.TwigSeedProp,
+                    mtree_props.twig_iteration,
+                    mtree_props.tree_number,
+                    mtree_props.batch_radius_randomness,
+                    mtree_props.batch_group_name,
+                    mtree_props.batch_space))
 
         # write to file
         prsets_directory = os.path.join(os.path.dirname(__file__), "mod_tree_presets")
-        prset = os.path.join(prsets_directory, scene.preset_name + ".mtp")  # mtp stands for modular tree preset
+        prset = os.path.join(prsets_directory, mtree_props.preset_name + ".mtp")  # mtp stands for modular tree preset
 
         os.makedirs(os.path.dirname(prset), exist_ok=True)
         with open(prset, 'w') as p:
@@ -240,7 +240,7 @@ class LoadTreePresetOperator(Operator):
     filename = StringProperty(name="File Name")
 
     def execute(self, context):
-        scene = context.scene
+        mtree_props = context.scene.mtree_props
 
         prsets_directory = os.path.join(os.path.dirname(__file__), "mod_tree_presets")
         prset = os.path.join(prsets_directory, self.filename)  # mtp stands for modular tree preset
@@ -253,98 +253,98 @@ class LoadTreePresetOperator(Operator):
             if ":" in line:
                 setting, value = line.split(":")
                 if setting == 'finish_unwrap':
-                    scene.finish_unwrap = bool(int(value))
+                    mtree_props.finish_unwrap = bool(int(value))
                 elif setting == "preserve_trunk":
-                    scene.preserve_trunk = bool(int(value))  # bools have to be converted to int first (stored as 0/1)
+                    mtree_props.preserve_trunk = bool(int(value))  # bools have to be converted to int first (stored as 0/1)
                 elif setting == "trunk_split_angle":
-                    scene.trunk_split_angle = float(value)
+                    mtree_props.trunk_split_angle = float(value)
                 elif setting == "randomangle":
-                    scene.randomangle = float(value)
+                    mtree_props.randomangle = float(value)
                 elif setting == "trunk_variation":
-                    scene.trunk_variation = float(value)
+                    mtree_props.trunk_variation = float(value)
                 elif setting == "radius":
-                    scene.radius = float(value)
+                    mtree_props.radius = float(value)
                 elif setting == "radius_dec":
-                    scene.radius_dec = float(value)
+                    mtree_props.radius_dec = float(value)
                 elif setting == "iteration":
-                    scene.iteration = int(value)
+                    mtree_props.iteration = int(value)
                 elif setting == "preserve_end":
-                    scene.preserve_end = int(value)
+                    mtree_props.preserve_end = int(value)
                 elif setting == "trunk_length":
-                    scene.trunk_length = int(value)
+                    mtree_props.trunk_length = int(value)
                 elif setting == "trunk_split_proba":
-                    scene.trunk_split_proba = float(value)
+                    mtree_props.trunk_split_proba = float(value)
                 elif setting == "split_proba":
-                    scene.split_proba = float(value)
+                    mtree_props.split_proba = float(value)
                 elif setting == "trunk_space":
-                    scene.trunk_space = float(value)
+                    mtree_props.trunk_space = float(value)
                 elif setting == "branch_length":
-                    scene.branch_length = float(value)
+                    mtree_props.branch_length = float(value)
                 elif setting == "split_angle":
-                    scene.split_angle = float(value)
+                    mtree_props.split_angle = float(value)
                 elif setting == "gravity_strength":
-                    scene.gravity_strength = float(value)
+                    mtree_props.gravity_strength = float(value)
                 elif setting == "gravity_start":
-                    scene.gravity_start = int(value)
+                    mtree_props.gravity_start = int(value)
                 elif setting == "gravity_end":
-                    scene.gravity_end = int(value)
+                    mtree_props.gravity_end = int(value)
                 elif setting == "obstacle":
-                    scene.obstacle = value.replace("\n", "")
+                    mtree_props.obstacle = value.replace("\n", "")
                 elif setting == "obstacle_strength":
-                    scene.obstacle_strength = float(value)
+                    mtree_props.obstacle_strength = float(value)
                 elif setting == "SeedProp":
-                    scene.SeedProp = int(value)
+                    mtree_props.SeedProp = int(value)
                 elif setting == "create_armature":
-                    scene.create_armature = bool(int(value))
+                    mtree_props.create_armature = bool(int(value))
                 elif setting == "bones_iterations":
-                    scene.bones_iterations = int(value)
+                    mtree_props.bones_iterations = int(value)
                 elif setting == "visualize_leafs":
-                    scene.visualize_leafs = bool(int(value))
+                    mtree_props.visualize_leafs = bool(int(value))
                 elif setting == "leafs_iteration_length":
-                    scene.leafs_iteration_length = int(value)
+                    mtree_props.leafs_iteration_length = int(value)
                 elif setting == "uv":
-                    scene.uv = bool(int(value))
+                    mtree_props.uv = bool(int(value))
                 elif setting == "unwrap_end_iteration":
-                    scene.unwrap_end_iteration = int(value)
+                    mtree_props.unwrap_end_iteration = int(value)
                 elif setting == "mat":
-                    scene.mat = bool(int(value))
+                    mtree_props.mat = bool(int(value))
                 elif setting == "roots_iteration":
-                    scene.roots_iteration = int(value)
+                    mtree_props.roots_iteration = int(value)
                 elif setting == "create_roots":
-                    scene.create_roots = bool(int(value))
+                    mtree_props.create_roots = bool(int(value))
                 elif setting == "branch_rotate":
-                    scene.branch_rotate = float(value)
+                    mtree_props.branch_rotate = float(value)
                 elif setting == "branch_random_rotate":
-                    scene.branch_random_rotate = float(value)
+                    mtree_props.branch_random_rotate = float(value)
                 elif setting == "particle":
-                    scene.particle = bool(int(value))
+                    mtree_props.particle = bool(int(value))
                 elif setting == "number":
-                    scene.number = int(value)
+                    mtree_props.number = int(value)
                 elif setting == "display":
-                    scene.display = int(value)
+                    mtree_props.display = int(value)
                 elif setting == "break_chance":
-                    scene.break_chance = float(value)
+                    mtree_props.break_chance = float(value)
                 elif setting == "bark_material":
-                    scene.bark_material = value.replace("\n", "")
+                    mtree_props.bark_material = value.replace("\n", "")
                 elif setting == "leaf_size":
-                    scene.leaf_size = float(value)
+                    mtree_props.leaf_size = float(value)
                 elif setting == "leaf_chance":
-                    scene.leaf_chance = float(value)
+                    mtree_props.leaf_chance = float(value)
                 elif setting == "twig_leaf_material":
-                    scene.twig_leaf_material = value.replace("\n", "")
+                    mtree_props.twig_leaf_material = value.replace("\n", "")
                 elif setting == "twig_bark_material":
-                    scene.twig_bark_material = value.replace("\n", "")
+                    mtree_props.twig_bark_material = value.replace("\n", "")
                 elif setting == "TwigSeedProp":
-                    scene.TwigSeedProp = int(value)
+                    mtree_props.TwigSeedProp = int(value)
                 elif setting == "twig_iteration":
-                    scene.twig_iteration = int(value)
+                    mtree_props.twig_iteration = int(value)
                 elif setting == "tree_number":
-                    scene.tree_number = int(value)
+                    mtree_props.tree_number = int(value)
                 elif setting == "batch_radius_randomness":
-                    scene.batch_radius_randomness = float(value)
+                    mtree_props.batch_radius_randomness = float(value)
                 elif setting == "batch_group_name":
-                    scene.batch_group_name = value.replace("\n", "")
+                    mtree_props.batch_group_name = value.replace("\n", "")
                 elif setting == "batch_space":
-                    scene.batch_space = float(value)
+                    mtree_props.batch_space = float(value)
 
         return {'FINISHED'}

--- a/wind_setup_utils.py
+++ b/wind_setup_utils.py
@@ -39,13 +39,13 @@ class WindOperator(Operator):
             self.report({message_lvls[i]}, message)
             return {status}
 
-        scene = context.scene
+        mtree_props = context.scene.mtree_props
 
         # check for control object and terrain
-        if not scene.terrain:
+        if not mtree_props.terrain:
             self.report({'ERROR'}, "Missing terrain object!")
             return {'CANCELLED'}
-        if not scene.wind_controller:
+        if not mtree_props.wind_controller:
             self.report({'ERROR'}, "Missing control object!")
             return {'CANCELLED'}
 
@@ -81,7 +81,7 @@ class WindOperator(Operator):
 
             wind_group.add([i for i in range(len(obj.data.vertices))], 1.0, "REPLACE")
 
-            if scene.clear_mods:
+            if mtree_props.clear_mods:
                 # remove all modifiers
                 [obj.modifiers.remove(m) for m in obj.modifiers]
 
@@ -91,9 +91,9 @@ class WindOperator(Operator):
             bpy.ops.object.modifier_add(type='VERTEX_WEIGHT_PROXIMITY')
             vwp = obj.modifiers[orig_mods_len]  # this is an index so if len(0), [0] will be correct
             vwp.vertex_group = wind_group.name
-            vwp.target = bpy.data.objects[scene.terrain]
-            vwp.min_dist = scene.wind_height_start
-            vwp.max_dist = scene.wind_height_full
+            vwp.target = bpy.data.objects[mtree_props.terrain]
+            vwp.min_dist = mtree_props.wind_height_start
+            vwp.max_dist = mtree_props.wind_height_full
             vwp.proximity_mode = 'GEOMETRY'
             vwp.proximity_geometry = {'FACE'}
 
@@ -101,9 +101,9 @@ class WindOperator(Operator):
             bpy.ops.object.modifier_add(type='DISPLACE')
             displace = obj.modifiers[orig_mods_len + 1]
             displace.texture_coords = 'OBJECT'
-            displace.texture_coords_object = bpy.data.objects[scene.wind_controller]
+            displace.texture_coords_object = bpy.data.objects[mtree_props.wind_controller]
             displace.direction = 'RGB_TO_XYZ'
-            displace.strength = scene.wind_strength
+            displace.strength = mtree_props.wind_strength
             displace.texture = bpy.data.textures[wind_texture.name]
             displace.vertex_group = wind_group.name
 


### PR DESCRIPTION
This has not been thoroughly tested...I need some testers! Thanks to Zeffi for pointing out the property group feature in the issue tracker.

The properties are no longer accessed with:

bpy.context.scene.my_prop

but instead:

bpy.context.scene.mtree_props.my_prop

This should clean up the scene props so as to avoid conflicts with other add-ons :)