### PR TITLE
Update README.md with blender_28 branch info

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ This addon for blender allows the creation of realistic trees with the node edit
 
 Documentation: https://github.com/MaximeHerpin/modular_tree/wiki/Documentation
 
+For users of Blender 2.8x and newer download the blender_28 branch: https://github.com/MaximeHerpin/modular_tree/archive/blender_28.zip


### PR DESCRIPTION
I have added a notice to use the blender_28 branch for versions of Blender newer than 2.8x.