### PR TITLE
changed node_category name

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -109,12 +109,12 @@ def register():
     for cls in classes:
         register_class(cls)
 
-    nodeitems_utils.register_node_categories('CUSTOM_NODES', node_categories)
+    nodeitems_utils.register_node_categories('MTREE_NODES', node_categories)
 
 
 def unregister():
     addon_updater_ops.unregister()
-    nodeitems_utils.unregister_node_categories('CUSTOM_NODES')
+    nodeitems_utils.unregister_node_categories('MTREE_NODES')
 
     from bpy.utils import unregister_class
     for cls in reversed(classes):


### PR DESCRIPTION
The line which had 'CUSTOM_NODES' is a problem, if any other addon uses custom node trees and it also used 'CUSTOM_NODES' it would say 'CUSTOM_NODES' already registered, this fixes it